### PR TITLE
Migrate to proper esbuild, and upgrade algolia

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   workflow_run:
-    workflows: 
+    workflows:
       - Tests
-    branches: 
+    branches:
       - main
       - alpha
       - beta

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,6 @@
         "@web/dev-server": "^0.1.34",
         "@web/dev-server-esbuild": "^0.3.2",
         "@web/dev-server-legacy": "^1.0.1",
-        "@web/rollup-plugin-html": "^1.11.0",
-        "@web/rollup-plugin-polyfills-loader": "^1.3.1",
         "@web/test-runner": "^0.14.0",
         "@web/test-runner-playwright": "^0.8.10",
         "@webcomponents/webcomponentsjs": "^2.6.0",
@@ -14468,53 +14466,6 @@
         "systemjs": "^6.8.1",
         "terser": "^5.14.2",
         "whatwg-fetch": "^3.5.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@web/rollup-plugin-html": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@web/rollup-plugin-html/-/rollup-plugin-html-1.11.0.tgz",
-      "integrity": "sha512-EqUcV5plGYTV/utdbX8g5t8Yq/z6VfFuQuPD39ckOQuRj7Rj6HD15FHwLHpFAWOR0+GrDnNzR74RvI4ipGm0qQ==",
-      "dev": true,
-      "dependencies": {
-        "@web/parse5-utils": "^1.3.0",
-        "glob": "^7.1.6",
-        "html-minifier-terser": "^6.0.0",
-        "parse5": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@web/rollup-plugin-html/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@web/rollup-plugin-polyfills-loader": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@web/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.3.1.tgz",
-      "integrity": "sha512-dV73QWsGMFkCGwgs2l6ADmDFtsEIduTJLSBL5wBHp5wZm1Sy4SQAEGTsDMRDX5cpAHRT9+sUnKLLREfBppuJbA==",
-      "dev": true,
-      "dependencies": {
-        "@web/polyfills-loader": "^1.3.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -54353,43 +54304,6 @@
         "systemjs": "^6.8.1",
         "terser": "^5.14.2",
         "whatwg-fetch": "^3.5.0"
-      }
-    },
-    "@web/rollup-plugin-html": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@web/rollup-plugin-html/-/rollup-plugin-html-1.11.0.tgz",
-      "integrity": "sha512-EqUcV5plGYTV/utdbX8g5t8Yq/z6VfFuQuPD39ckOQuRj7Rj6HD15FHwLHpFAWOR0+GrDnNzR74RvI4ipGm0qQ==",
-      "dev": true,
-      "requires": {
-        "@web/parse5-utils": "^1.3.0",
-        "glob": "^7.1.6",
-        "html-minifier-terser": "^6.0.0",
-        "parse5": "^6.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "@web/rollup-plugin-polyfills-loader": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@web/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.3.1.tgz",
-      "integrity": "sha512-dV73QWsGMFkCGwgs2l6ADmDFtsEIduTJLSBL5wBHp5wZm1Sy4SQAEGTsDMRDX5cpAHRT9+sUnKLLREfBppuJbA==",
-      "dev": true,
-      "requires": {
-        "@web/polyfills-loader": "^1.3.4"
       }
     },
     "@web/test-runner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@docsearch/js": "^3.3.0",
         "lit": "^2.4.0",
         "outdent": "^0.8.0"
       },
@@ -88,6 +89,146 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
       "dev": true
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "dependencies": {
+        "@algolia/logger-common": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -2298,6 +2439,47 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.0.tgz",
+      "integrity": "sha512-oFXWRPNvPxAzBhnFJ9UCFIYZiQNc3Yrv6912nZHw/UIGxsyzKpNRZgHq8HDk1niYmOSoLKtVFcxkccpQmYGFyg==",
+      "dependencies": {
+        "@docsearch/react": "3.3.0",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
+        "algoliasearch": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
@@ -13853,7 +14035,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -13871,7 +14053,7 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -13903,7 +14085,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -15091,6 +15273,27 @@
       "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.14.2",
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/cache-in-memory": "4.14.2",
+        "@algolia/client-account": "4.14.2",
+        "@algolia/client-analytics": "4.14.2",
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-personalization": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/logger-console": "4.14.2",
+        "@algolia/requester-browser-xhr": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/requester-node-http": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/ansi-align": {
@@ -18832,7 +19035,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/custom-elements-manifest": {
       "version": "1.0.0",
@@ -28890,7 +29093,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -29919,7 +30122,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -35059,7 +35262,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -36383,6 +36586,15 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -36574,7 +36786,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -36914,7 +37126,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -36938,7 +37150,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -36962,7 +37174,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/react-merge-refs": {
       "version": "1.1.0",
@@ -38719,7 +38931,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -43507,6 +43719,142 @@
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
       "dev": true
     },
+    "@algolia/autocomplete-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      }
+    },
+    "@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      }
+    },
+    "@algolia/autocomplete-shared": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+    },
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-personalization": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "requires": {
+        "@algolia/logger-common": "4.14.2"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -45065,6 +45413,31 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
+    },
+    "@docsearch/css": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
+    },
+    "@docsearch/js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.0.tgz",
+      "integrity": "sha512-oFXWRPNvPxAzBhnFJ9UCFIYZiQNc3Yrv6912nZHw/UIGxsyzKpNRZgHq8HDk1niYmOSoLKtVFcxkccpQmYGFyg==",
+      "requires": {
+        "@docsearch/react": "3.3.0",
+        "preact": "^10.0.0"
+      }
+    },
+    "@docsearch/react": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
+        "algoliasearch": "^4.0.0"
+      }
     },
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
@@ -53825,7 +54198,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -53843,7 +54216,7 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -53875,7 +54248,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -54864,6 +55237,27 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "requires": {}
+    },
+    "algoliasearch": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.14.2",
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/cache-in-memory": "4.14.2",
+        "@algolia/client-account": "4.14.2",
+        "@algolia/client-analytics": "4.14.2",
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-personalization": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/logger-console": "4.14.2",
+        "@algolia/requester-browser-xhr": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/requester-node-http": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -57736,7 +58130,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "devOptional": true
     },
     "custom-elements-manifest": {
       "version": "1.0.0",
@@ -65357,7 +65751,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -66195,7 +66589,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -69890,7 +70284,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "devOptional": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -70875,6 +71269,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -71013,7 +71412,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -71280,7 +71679,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -71298,7 +71697,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -71317,7 +71716,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "devOptional": true
     },
     "react-merge-refs": {
       "version": "1.1.0",
@@ -72672,7 +73071,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "main": "build/jio-components.cjs.js",
-  "module": "build/jio-components.ejs.js",
+  "module": "build/jio-components.esm.js",
   "type": "module",
   "browserslist": [
     "last 2 versions",
@@ -81,8 +81,6 @@
     "@web/dev-server": "^0.1.34",
     "@web/dev-server-esbuild": "^0.3.2",
     "@web/dev-server-legacy": "^1.0.1",
-    "@web/rollup-plugin-html": "^1.11.0",
-    "@web/rollup-plugin-polyfills-loader": "^1.3.1",
     "@web/test-runner": "^0.14.0",
     "@web/test-runner-playwright": "^0.8.10",
     "@webcomponents/webcomponentsjs": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "author": "Gavin Mogan <npm@gavinmogan.com> (https://www.gavinmogan.com/)",
   "license": "MIT",
   "dependencies": {
+    "@docsearch/js": "^3.3.0",
     "lit": "^2.4.0",
     "outdent": "^0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   ],
   "release": {
     "branches": [
-      "main"
+      "main",
+      "alpha",
+      "beta"
     ]
   },
   "author": "Gavin Mogan <npm@gavinmogan.com> (https://www.gavinmogan.com/)",

--- a/src/jio-searchbox.ts
+++ b/src/jio-searchbox.ts
@@ -1,6 +1,5 @@
-import {LitElement, html, css} from 'lit';
+import {LitElement, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {ref, createRef} from 'lit/directives/ref.js';
 
 declare global {
   interface Window {
@@ -21,45 +20,27 @@ export class Searchbox extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    if (!window.docsearch) {
-      // have to add css to both the page (for popup) and webcomponent (button)
-      [document.head, this.renderRoot].forEach(root => {
-        const linkFileEl = document.createElement('link');
-        linkFileEl.setAttribute('rel', 'stylesheet');
-        linkFileEl.setAttribute('type', 'text/css');
-        linkFileEl.setAttribute('href', `https://cdn.jsdelivr.net/npm/@docsearch/css@3`);
-        linkFileEl.setAttribute('media', 'all');
-        root.appendChild(linkFileEl);
-      });
-
-      const scriptFileEl = document.createElement('script');
-      scriptFileEl.setAttribute('defer', '');
-      scriptFileEl.setAttribute('src', `https://cdn.jsdelivr.net/npm/@docsearch/js@3`);
-      document.head.appendChild(scriptFileEl);
-      scriptFileEl.addEventListener('load', this.onAlgoliaReady.bind(this));
-    } else {
-      setTimeout(this.onAlgoliaReady.bind(this), 0);
-    }
-  }
-
-  private onAlgoliaReady() {
-    window.docsearch({
-      container: this.searchRef.value!,
-      indexName: 'jenkins',
-      appId: "M6L7Q4Z8HS",
-      apiKey: "52f8dfbff76ffd9106f1c68fee16154b",
-      searchParameters: {
-        facetFilters: ["lang:en"],
-      },
-      debug: false
+    // have to add css to both the page (for popup) and webcomponent (button)
+    [document.head, this.renderRoot].forEach(root => {
+      const linkFileEl = document.createElement('link');
+      linkFileEl.setAttribute('rel', 'stylesheet');
+      linkFileEl.setAttribute('type', 'text/css');
+      linkFileEl.setAttribute('href', `https://cdn.jsdelivr.net/npm/@docsearch/css@3`);
+      linkFileEl.setAttribute('media', 'all');
+      root.appendChild(linkFileEl);
     });
-    this._isReady = true;
-  }
-
-  private searchRef = createRef();
-
-  override render() {
-    return html`<div data-testid="searchbox"><div ${ref(this.searchRef)}></div></div>`;
+    import('@docsearch/js').then(({default: docsearch}) => {
+      docsearch({
+        container: this.renderRoot as HTMLElement,
+        indexName: 'jenkins',
+        appId: "M6L7Q4Z8HS",
+        apiKey: "52f8dfbff76ffd9106f1c68fee16154b",
+        searchParameters: {
+          facetFilters: ["lang:en"],
+        },
+      });
+      this._isReady = true;
+    });
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": false,
-    "inlineSources": true,
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
chore: Migrate rollup to produce es (modern javascript). I had esm and ejs which were not correct, rollup just ignored those values
fix: navbar loads docsearch from bundle (on demand) which is way easier to detect when finished loading.