### PR TITLE
Fix: Re-order search icon on mobile for better experience

### DIFF
--- a/src/jio-navbar.css
+++ b/src/jio-navbar.css
@@ -186,6 +186,18 @@ button.nav-link {
 @media (max-width: 991px) {
   .navbar-toggler {
     display: block;
+    margin-left: 0;
+    order: 4;
+  }
+
+  jio-searchbox {
+    margin-left: auto;
+    margin-right: 10px;
+    order: 3;
+  }
+
+  .navbar-menu {
+    order: 5;
   }
 
   .navbar {

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -183,7 +183,7 @@ export class Navbar extends LitElement {
       }
       return body;
     });
-    let searchboxHtml = html``;
+    let searchboxHtml = null;
     if (this.showSearchBox) {
       searchboxHtml = html`<jio-searchbox></jio-searchbox>`;
     }
@@ -194,10 +194,16 @@ export class Navbar extends LitElement {
             <a href="/">Jenkins</a>
           </slot>
         </span>
-        <button class="navbar-toggler collapsed btn" type="button" @click=${this._clickCollapseButton} aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button
+          class="navbar-toggler collapsed btn"
+          type="button"
+          @click=${this._clickCollapseButton}
+          aria-controls="navbarSupportedContent"
+          aria-expanded=${this.menuToggled}
+          aria-label="Toggle navigation">
           <ion-icon name="menu-outline" title="Toggle Menu Visible"></ion-icon>
         </button>
-        <div class="collapse ${this.menuToggled ? "show" : ""}">
+        <div class="navbar-menu collapse ${this.menuToggled ? "show" : ""}">
           <ul class="nav navbar-nav mr-auto">
             ${this.renderNavItemDropdown({label: html`<jio-cdf-logo></jio-cdf-logo>`, link: cdfMenuItems}, 99, this.visibleMenu === 99)}
           </ul>

--- a/src/jio-searchbox.ts
+++ b/src/jio-searchbox.ts
@@ -1,4 +1,4 @@
-import {LitElement, css, unsafeCSS} from 'lit';
+import {LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
 
 declare global {
@@ -10,8 +10,6 @@ declare global {
 
 @customElement('jio-searchbox')
 export class Searchbox extends LitElement {
-  static override styles = css``;
-
   get isReady() {
     return this._isReady;
   }


### PR DESCRIPTION
Sadly changing order by css messes with tab order, but having it search, then menu toggler, then menu on mobile view, means things stay consistent when menu is expanded.

new: 
![image](https://user-images.githubusercontent.com/110087/204063942-0135c3c6-9709-4ecc-ac19-dec1fde1ca64.png)

old:
![image](https://user-images.githubusercontent.com/110087/204063981-787c37c9-cc3a-4dea-a3bf-fbeeb4c32f7e.png)

