### PR TITLE
Update tekton URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ shared-*.d.ts
 shared-*.d.ts.map
 shared-*.js
 shared-*.js.map
+.idea

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -77,7 +77,7 @@ export class Navbar extends LitElement {
     const cdfMenuItems = [
       {label: "What is CDF?", link: "https://cd.foundation/"},
       {label: "Jenkins X", link: "https://jenkins-x.io/"},
-      {label: "Tekton", link: "https://cloud.google.com/tekton/"},
+      {label: "Tekton", link: "https://tekton.dev/"},
       {label: "Spinnaker", link: "https://www.spinnaker.io/"},
     ];
     const menuItems = [


### PR DESCRIPTION
Let's use the up-to-date website URL of tekton, found in various tekton docs itself.