### PR TITLE
fix: Hardcode locale

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,14 +14,16 @@ import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
 const processor = postcss(require('./postcss.config.cjs'));
 
+const input = [].concat(
+  readdirSync('./src/').filter(file => file.endsWith('.ts')).map(file => `src/${file}`)
+).concat(
+  readdirSync('./src/generated/locales/').filter(file => file.endsWith('.ts')).map(file => `src/generated/locales/${file}`)
+).reduce((prev, cur) => {prev[cur.replace('src/', '').replace(/\.[tj]s$/, '')] = cur; return prev;}, {});
+
 export default {
   // Entry point for application build; can specify a glob to build multiple
   // HTML files for non-SPA app
-  input: [].concat(
-    readdirSync('./src/').filter(file => file.endsWith('.ts')).map(file => `src/${file}`)
-  ).concat(
-    readdirSync('./src/generated/locales/').filter(file => file.endsWith('.ts')).map(file => `src/generated/locales/${file}`)
-  ),
+  input,
   plugins: [
     litcss({
       include: '/**/*.css',

--- a/src/jio-locale.ts
+++ b/src/jio-locale.ts
@@ -4,7 +4,16 @@ import {sourceLocale, targetLocales} from './generated/locale-codes';
 export const {getLocale, setLocale} = configureLocalization({
   sourceLocale,
   targetLocales,
-  loadLocale: (locale: string) => import(`./generated/locales/${locale}`),
+  loadLocale: (locale: string) => {
+    if (locale === 'en') {
+      return import(`./generated/locales/en`);
+    } else if (locale === 'es-ES') {
+      return import(`./generated/locales/es-ES`);
+    } else if (locale === 'fr-CA') {
+      return import(`./generated/locales/fr-CA`);
+    }
+    return Promise.reject(`${locale} not found`);
+  },
 });
 
 export const setLocaleFromUrl = async () => {


### PR DESCRIPTION
instead of loading `./generated/locales/${locale}` which doesn't seem to translate properly, just hardcode the locale options for now and let them get loaded