### PR TITLE
fix: Search wasn't returning items in priority order

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "iOS >= 8"
   ],
   "scripts": {
-    "dev": "rollup -c --watch",
+    "dev": "npx storybook dev -p 6006",
     "build": "rollup -c",
     "build:watch": "rollup -c --watch",
     "clean": "rimraf build jio-*.{d.ts,d.ts.map,js,js.map} test/jio-*.{d.ts,d.ts.map,js,js.map} test/jio-*_test.{d.ts,d.ts.map,js,js.map} shared-styles.{d.ts,d.ts.map,js,js.map}",

--- a/src/jio-searchbox.ts
+++ b/src/jio-searchbox.ts
@@ -54,7 +54,6 @@ export class Searchbox extends LitElement {
         appId: "M6L7Q4Z8HS",
         apiKey: "52f8dfbff76ffd9106f1c68fee16154b",
         searchParameters: {
-          facetFilters: ["lang:en"],
         },
       });
       this._isReady = true;


### PR DESCRIPTION
Apparently requesting english only results messed with all the other ranking realted search settings, so for now (since we only have english only results), just use default search settings