### PR TITLE
Remove references to sunset chinese website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ shared-*.d.ts.map
 shared-*.js
 shared-*.js.map
 .idea
+eslint-results.json
+stylelint-results.json

--- a/src/generated/locales/en.ts
+++ b/src/generated/locales/en.ts
@@ -67,8 +67,6 @@
 's5b6e52ea97400a5f': `Awards`,
 's3069cdedba617e6f': `Conduct`,
 's74bec541bd25310f': `Artwork`,
-'s4caed5b7a7e5d89b': `English`,
-'sa64d0efb4c0ded72': `中文 Chinese`,
 'sfc5ae29537c2d728': `Creative Commons Attribution-ShareAlike license`,
 's689b7846e70a2db2': `The content driving this site is licensed under the Creative Commons Attribution-ShareAlike 4.0 license.`,
 's175d37c8eb04d73e': `Downloads`,
@@ -85,4 +83,3 @@
 'se071f4c919dd94aa': `Press information`,
 's5eccbe991f054d30': `Merchandise`,
     };
-  

--- a/src/generated/locales/es-ES.ts
+++ b/src/generated/locales/es-ES.ts
@@ -67,8 +67,6 @@
 's5b6e52ea97400a5f': `Awards`,
 's3069cdedba617e6f': `Conduct`,
 's74bec541bd25310f': `Artwork`,
-'s4caed5b7a7e5d89b': `English`,
-'sa64d0efb4c0ded72': `中文 Chinese`,
 'sfc5ae29537c2d728': `Creative Commons Attribution-ShareAlike license`,
 's689b7846e70a2db2': `The content driving this site is licensed under the Creative Commons Attribution-ShareAlike 4.0 license.`,
 's175d37c8eb04d73e': `Downloads`,
@@ -85,4 +83,3 @@
 'se071f4c919dd94aa': `Press information`,
 's5eccbe991f054d30': `Merchandise`,
     };
-  

--- a/src/generated/locales/fr-CA.ts
+++ b/src/generated/locales/fr-CA.ts
@@ -67,8 +67,6 @@
 's5b6e52ea97400a5f': `Awards`,
 's3069cdedba617e6f': `Conduct`,
 's74bec541bd25310f': `Artwork`,
-'s4caed5b7a7e5d89b': `English`,
-'sa64d0efb4c0ded72': `中文 Chinese`,
 'sfc5ae29537c2d728': `Creative Commons Attribution-ShareAlike license`,
 's689b7846e70a2db2': `The content driving this site is licensed under the Creative Commons Attribution-ShareAlike 4.0 license.`,
 's175d37c8eb04d73e': `Downloads`,
@@ -85,4 +83,3 @@
 'se071f4c919dd94aa': `Press information`,
 's5eccbe991f054d30': `Merchandise`,
     };
-  

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -178,11 +178,6 @@ export class Navbar extends LitElement {
           {label: msg("Conduct"), link: "/project/conduct/"},
           {label: msg("Artwork"), link: "/artwork/"},
         ]
-      },
-      {
-        label: msg("English"), link: [
-          {label: msg("中文 Chinese"), link: "/zh/"},
-        ]
       }
     ] as Array<NavbarItemLink>;
     const menuItemsHtml = menuItems.map((menuItem, idx) => {

--- a/xliff/en.xlf
+++ b/xliff/en.xlf
@@ -176,12 +176,6 @@
 <trans-unit id="s74bec541bd25310f">
   <source>Artwork</source>
 </trans-unit>
-<trans-unit id="s4caed5b7a7e5d89b">
-  <source>English</source>
-</trans-unit>
-<trans-unit id="sa64d0efb4c0ded72">
-  <source>中文 Chinese</source>
-</trans-unit>
 <trans-unit id="sfc5ae29537c2d728">
   <source>Creative Commons Attribution-ShareAlike license</source>
 </trans-unit>

--- a/xliff/es-ES.xlf
+++ b/xliff/es-ES.xlf
@@ -218,14 +218,6 @@
         <source>Artwork</source>
         <target state="needs-translation">Artwork</target>
       </trans-unit>
-      <trans-unit id="s4caed5b7a7e5d89b">
-        <source>English</source>
-        <target state="needs-translation">English</target>
-      </trans-unit>
-      <trans-unit id="sa64d0efb4c0ded72">
-        <source>中文 Chinese</source>
-        <target state="needs-translation">中文 Chinese</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/xliff/fr-CA.xlf
+++ b/xliff/fr-CA.xlf
@@ -218,14 +218,6 @@
         <source>Artwork</source>
         <target state="needs-translation">Artwork</target>
       </trans-unit>
-      <trans-unit id="s4caed5b7a7e5d89b">
-        <source>English</source>
-        <target state="needs-translation">English</target>
-      </trans-unit>
-      <trans-unit id="sa64d0efb4c0ded72">
-        <source>中文 Chinese</source>
-        <target state="needs-translation">中文 Chinese</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
The chinese website remains almost unmodified since 2019 and there are ongoing efforts to detach it from our resources. 
I would like to remove it from the navbar component. Not only for the reason that it's in a sunset state, but also to draw focus on jenkins.io and prevent future misguidance of newbie contributors and GSoC students who want to contribute.