### PR TITLE
fix(reportaproblem): Switch to GH issue form syntax

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -58,6 +58,12 @@ export class Footer extends LitElement {
    @property()
    githubBranch = 'master';
 
+   /**
+    * The name of the bug report template to use
+    */
+   @property({ type: String })
+   reportAProblemTemplate = ""
+
    override render() {
       return html`
 <footer>

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -61,8 +61,8 @@ export class Footer extends LitElement {
    /**
     * The name of the bug report template to use
     */
-   @property({ type: String })
-   reportAProblemTemplate = ""
+   @property({type: String})
+   reportAProblemTemplate = "";
 
    override render() {
       return html`
@@ -72,7 +72,7 @@ export class Footer extends LitElement {
          <div class="col-md-4">
             <p class="box">
                <jio-improve-this-page sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)}></jio-improve-this-page>
-               <jio-report-a-problem sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)}></jio-report-a-problem>
+               <jio-report-a-problem sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)} .template=${ifDefined(this.reportAProblemTemplate)}></jio-report-a-problem>
             </p>
             <div class="license-box">
               ${licenseHtmls[this.license] || html``}

--- a/src/jio-report-a-problem.ts
+++ b/src/jio-report-a-problem.ts
@@ -76,7 +76,6 @@ export class ReportAProblem extends LitElement {
       const queryParams = new URLSearchParams();
       queryParams.append('labels', 'bug');
       queryParams.append('template', '4-bug.yml');
-      queryParams.append('title', `${title} - TODO: Describe what's wrong`);
       queryParams.append('problem', outdent`
         ${[
         `[${title}](${url}) page`,

--- a/src/jio-report-a-problem.ts
+++ b/src/jio-report-a-problem.ts
@@ -67,25 +67,13 @@ export class ReportAProblem extends LitElement {
 
     const queryParams = new URLSearchParams();
     queryParams.append('labels', 'bug');
-    queryParams.append('template', '4-bug.md');
-    queryParams.append('title', `${title} page - TODO: Put a summary here`);
-    queryParams.append('body', outdent`
+    queryParams.append('template', '4-bug.yml');
+    queryParams.append('title', `${title} - TODO: Describe what's wrong`);
+    queryParams.append('problem', outdent`
         ${[
-        `Problem with the [${title}](${url}) page`,
+        `[${title}](${url}) page`,
         sourcePath ?? `[source file](https://github.com/${githubRepo}/tree/${githubBranch}/src/${sourcePath})`
-      ].filter(Boolean).join(', ')}
-
-        TODO: Describe the expected and actual behavior here
-
-        # Screenshots
-
-        TODO: Add screenshots if possible
-
-        # Possible Solution
-
-        <!-- If you have suggestions on a fix for the bug, please describe it here. -->
-
-        N/A`);
+      ].filter(Boolean).join(', ')}`);
     const pluginSiteReportUrl = `https://github.com/${githubRepo}/issues/new?${queryParams.toString()}`;
     return html`
       <a href=${pluginSiteReportUrl} title=${msg(str`Report a problem with ${sourcePath || url}`)}>

--- a/src/jio-report-a-problem.ts
+++ b/src/jio-report-a-problem.ts
@@ -46,10 +46,10 @@ export class ReportAProblem extends LitElement {
   githubBranch = 'master';
 
   /**
-   * Whether to use the plugin site report URL
+   * The name of the bug report template to use
    */
-  @property({ type: Boolean })
-  usePluginSiteReportUrl = false;
+  @property({ type: String })
+  template = '';
 
   get locationHref() {
     const _location = typeof location !== 'undefined' ? location : {href: 'http://unknown'};
@@ -71,7 +71,7 @@ export class ReportAProblem extends LitElement {
     const url = this.url || this.locationHref;
     const title = this.pageTitle || this.windowTitle;
 
-    if (this.usePluginSiteReportUrl) {
+    if (this.template != null) {
 
       const queryParams = new URLSearchParams();
       queryParams.append('labels', 'bug');

--- a/src/jio-report-a-problem.ts
+++ b/src/jio-report-a-problem.ts
@@ -45,6 +45,12 @@ export class ReportAProblem extends LitElement {
   @property()
   githubBranch = 'master';
 
+  /**
+   * Whether to use the plugin site report URL
+   */
+  @property({ type: Boolean })
+  usePluginSiteReportUrl = false;
+
   get locationHref() {
     const _location = typeof location !== 'undefined' ? location : {href: 'http://unknown'};
     return _location.href;
@@ -65,22 +71,27 @@ export class ReportAProblem extends LitElement {
     const url = this.url || this.locationHref;
     const title = this.pageTitle || this.windowTitle;
 
-    const queryParams = new URLSearchParams();
-    queryParams.append('labels', 'bug');
-    queryParams.append('template', '4-bug.yml');
-    queryParams.append('title', `${title} - TODO: Describe what's wrong`);
-    queryParams.append('problem', outdent`
+    if (this.usePluginSiteReportUrl) {
+
+      const queryParams = new URLSearchParams();
+      queryParams.append('labels', 'bug');
+      queryParams.append('template', '4-bug.yml');
+      queryParams.append('title', `${title} - TODO: Describe what's wrong`);
+      queryParams.append('problem', outdent`
         ${[
         `[${title}](${url}) page`,
         sourcePath ?? `[source file](https://github.com/${githubRepo}/tree/${githubBranch}/src/${sourcePath})`
       ].filter(Boolean).join(', ')}`);
-    const pluginSiteReportUrl = `https://github.com/${githubRepo}/issues/new?${queryParams.toString()}`;
-    return html`
-      <a href=${pluginSiteReportUrl} title=${msg(str`Report a problem with ${sourcePath || url}`)}>
-        <ion-icon class="report" name="warning"></ion-icon>
-        <span class="text">${msg('Report a problem')}</span>
-      </a>
-    `;
+      const pluginSiteReportUrl = `https://github.com/${githubRepo}/issues/new?${queryParams.toString()}`;
+      return html`
+        <a href=${pluginSiteReportUrl} title=${msg(str`Report a problem with ${sourcePath || url}`)}>
+          <ion-icon class="report" name="warning"></ion-icon>
+          <span class="text">${msg('Report a problem')}</span>
+        </a>
+      `;
+    } else {
+      return null;
+    }
   }
 }
 
@@ -89,4 +100,3 @@ declare global {
     'jio-report-a-problem': ReportAProblem;
   }
 }
-

--- a/src/stories/Footer.stories.ts
+++ b/src/stories/Footer.stories.ts
@@ -2,7 +2,7 @@ import {StoryObj, Meta} from '@storybook/web-components';
 
 import {html} from 'lit';
 import {ifDefined} from 'lit/directives/if-defined.js';
-// import {deepQuerySelectorAll} from "shadow-dom-testing-library";
+import {deepQuerySelectorAll} from "shadow-dom-testing-library";
 import {expect} from '@storybook/jest';
 
 import {Footer} from '../jio-footer';
@@ -22,11 +22,12 @@ export default {
   }
 } as Meta;
 
-const render = ({property, sourcePath, githubRepo, githubBranch}) => html`<jio-footer
+const render = ({property, sourcePath, githubRepo, githubBranch, reportAProblemTemplate}) => html`<jio-footer
   property=${ifDefined(property)}
   sourcePath=${ifDefined(sourcePath)}
   githubRepo=${ifDefined(githubRepo)}
   githubBranch=${ifDefined(githubBranch)}
+  reportAProblemTemplate=${ifDefined(reportAProblemTemplate)}
 ></jio-footer>`;
 
 export const Default: StoryObj<Footer> = {
@@ -73,5 +74,28 @@ export const ExternalProperty: StoryObj<Footer> = {
     property: 'https://accounts.jenkins.io',
     githubRepo: 'jenkins-infra/jenkins-io-components',
     sourcePath: 'src/stories/Footer.stories.ts',
+  }
+};
+
+export const JenkinsIOBugTemplate: StoryObj<Footer> = {
+  render,
+  args: {
+    property: 'https://webcomponents.jenkins.io',
+    sourcePath: 'src/stories/ReportAProblem.ts',
+    githubRepo: 'halkeye/fake-jenkins-io-issue-templates',
+    githubBranch: 'main',
+    reportAProblemTemplate: '4-bug.yml',
+  },
+  play: async ({canvasElement}) => {
+    const reportAProblem = deepQuerySelectorAll(canvasElement, 'jio-report-a-problem')[0] as ReportAProblem;
+    expect(reportAProblem.shadowRoot.children).toHaveLength(1);
+    expect(reportAProblem.shadowRoot.querySelector('a')).toHaveAttribute('title', 'Report a problem with src/stories/ReportAProblem.ts');
+    expect(reportAProblem.shadowRoot.querySelector('a ion-icon')).toHaveAttribute('name', 'warning');
+    expect(reportAProblem.shadowRoot.querySelector('a span')).toHaveTextContent('Report a problem');
+
+    const url = new URL(reportAProblem.shadowRoot.querySelector('a').getAttribute('href'));
+    expect(Array.from(url.searchParams.keys()).sort()).toEqual(['labels', 'problem', 'template']);
+    expect(url.searchParams.get('labels')).toEqual('bug');
+    expect(url.searchParams.get('template')).toEqual('4-bug.yml');
   }
 };

--- a/src/stories/ReportAProblem.stories.ts
+++ b/src/stories/ReportAProblem.stories.ts
@@ -11,12 +11,12 @@ export default {
   component: 'jio-report-a-problem',
 } as Meta;
 
-const render = ({githubRepo, sourcePath, pageTitle, url, usePluginSiteReportUrl}) => html`<jio-report-a-problem
+const render = ({githubRepo, sourcePath, pageTitle, url, template}) => html`<jio-report-a-problem
   sourcePath=${ifDefined(sourcePath)}
   githubRepo=${ifDefined(githubRepo)}
   pageTitle=${ifDefined(pageTitle)}
   url=${ifDefined(url)}
-  usePluginSiteReportUrl=${ifDefined(usePluginSiteReportUrl)}
+  template=${ifDefined(template)}
 ></jio-report-a-problem>`;
 
 const expectToBeUrlEncoded = (href: string, {title, url, githubRepo}) => {
@@ -45,7 +45,7 @@ export const RepoAndSourcePath: StoryObj<ReportAProblem> = {
   args: {
     sourcePath: 'src/stories/ReportAProblem.ts',
     githubRepo: 'jenkins-infra/jenkins-io-components',
-    usePluginSiteReportUrl: true,
+    template: '4-bug.yml',
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;
@@ -81,7 +81,7 @@ export const NoSourcePath: StoryObj<ReportAProblem> = {
   render,
   args: {
     githubRepo: 'jenkins-infra/jenkins-io-components',
-    usePluginSiteReportUrl: true,
+    template: '4-bug.yml',
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;

--- a/src/stories/ReportAProblem.stories.ts
+++ b/src/stories/ReportAProblem.stories.ts
@@ -11,11 +11,12 @@ export default {
   component: 'jio-report-a-problem',
 } as Meta;
 
-const render = ({githubRepo, sourcePath, pageTitle, url}) => html`<jio-report-a-problem
+const render = ({githubRepo, sourcePath, pageTitle, url, usePluginSiteReportUrl}) => html`<jio-report-a-problem
   sourcePath=${ifDefined(sourcePath)}
   githubRepo=${ifDefined(githubRepo)}
   pageTitle=${ifDefined(pageTitle)}
   url=${ifDefined(url)}
+  usePluginSiteReportUrl=${ifDefined(usePluginSiteReportUrl)}
 ></jio-report-a-problem>`;
 
 const expectToBeUrlEncoded = (href: string, {title, url, githubRepo}) => {
@@ -24,7 +25,6 @@ const expectToBeUrlEncoded = (href: string, {title, url, githubRepo}) => {
   expect(href).toContain(`https://github.com/${githubRepo}/issues/new`);
   expect(href).toContain(new URLSearchParams({title}).toString());
   expect(href).toContain(encodeURIComponent(url));
-  expect(hrefURL.searchParams.get('title') || '').toEqual(`${title} - TODO: Put a summary here`);
   expect(hrefURL.searchParams.get('body') || '').toContain(url);
 
   const nonHrefBodyLines = hrefURL.searchParams.get('body')?.split('\n')?.filter(line => line.startsWith(' '));
@@ -45,6 +45,7 @@ export const RepoAndSourcePath: StoryObj<ReportAProblem> = {
   args: {
     sourcePath: 'src/stories/ReportAProblem.ts',
     githubRepo: 'jenkins-infra/jenkins-io-components',
+    usePluginSiteReportUrl: true,
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;
@@ -80,6 +81,7 @@ export const NoSourcePath: StoryObj<ReportAProblem> = {
   render,
   args: {
     githubRepo: 'jenkins-infra/jenkins-io-components',
+    usePluginSiteReportUrl: true,
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;

--- a/src/stories/ReportAProblem.stories.ts
+++ b/src/stories/ReportAProblem.stories.ts
@@ -45,7 +45,6 @@ export const RepoAndSourcePath: StoryObj<ReportAProblem> = {
   args: {
     sourcePath: 'src/stories/ReportAProblem.ts',
     githubRepo: 'jenkins-infra/jenkins-io-components',
-    template: '4-bug.yml',
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;
@@ -81,7 +80,6 @@ export const NoSourcePath: StoryObj<ReportAProblem> = {
   render,
   args: {
     githubRepo: 'jenkins-infra/jenkins-io-components',
-    template: '4-bug.yml',
   },
   play: async ({canvasElement, args}) => {
     const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;
@@ -137,5 +135,27 @@ export const OverrideURL: StoryObj<ReportAProblem> = {
       reportAProblem.shadowRoot.querySelector('a').getAttribute('href'),
       {url: 'https://google.com/', title: 'thingie page', githubRepo: args.githubRepo}
     );
+  }
+};
+
+export const JenkinsIOBugTemplate: StoryObj<ReportAProblem> = {
+  render,
+  args: {
+    sourcePath: 'src/stories/ReportAProblem.ts',
+    githubRepo: 'halkeye/fake-jenkins-io-issue-templates',
+    githubBranch: 'main',
+    template: '4-bug.yml',
+  },
+  play: async ({canvasElement}) => {
+    const reportAProblem = canvasElement.querySelector('jio-report-a-problem') as ReportAProblem;
+    expect(reportAProblem.shadowRoot.children).toHaveLength(1);
+    expect(reportAProblem.shadowRoot.querySelector('a')).toHaveAttribute('title', 'Report a problem with src/stories/ReportAProblem.ts');
+    expect(reportAProblem.shadowRoot.querySelector('a ion-icon')).toHaveAttribute('name', 'warning');
+    expect(reportAProblem.shadowRoot.querySelector('a span')).toHaveTextContent('Report a problem');
+
+    const url = new URL(reportAProblem.shadowRoot.querySelector('a').getAttribute('href'));
+    expect(Array.from(url.searchParams.keys()).sort()).toEqual(['labels', 'problem', 'template']);
+    expect(url.searchParams.get('labels')).toEqual('bug');
+    expect(url.searchParams.get('template')).toEqual('4-bug.yml');
   }
 };


### PR DESCRIPTION
This PR adapts the GitHub issue form syntax. `problem` matches the unique ID, I gave the issue field this information should be filled in to.
The default body can be removed by now because I incorporated it into the issue form default.

This PR depends on the following jenkins.io PR: https://github.com/jenkins-infra/jenkins.io/pull/6086