### PR TITLE
feat: Removed sub sections of `Tutorial` from documentation dropdown

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -101,8 +101,6 @@ export class Navbar extends LitElement {
           {
             label: msg("Tutorials"), link: "/doc/tutorials", header: true
           },
-          {label: "- " + msg("Guided Tour"), link: "/doc/pipeline/tour/getting-started/"},
-          {label: "- " + msg("More Tutorials"), link: "/doc/tutorials/"},
           {
             label: msg("Developer Guide"), link: "/doc/developer", header: true
           },


### PR DESCRIPTION
To prevent making the documentation dropdown menu of the navbar even longer, two sub-menus, `Guided Tour` and `More Tutorials`, now there, need to be removed. 
For more details please refer to the following PR: https://github.com/jenkins-infra/jenkins-io-components/pull/79