### PR TITLE
feat: Add stories.jenkins.io to navbar

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -85,6 +85,7 @@ export class Navbar extends LitElement {
     ];
     const menuItems = [
       {label: msg("Blog"), link: "/node"},
+      {label: msg("Success Stories"), link: "https://stories.jenkins.io/"},
       {
         label: msg("Documentation"), link: [
           {


### PR DESCRIPTION
I believe adding stories.jenkins.io in a prominent location like the navbar draws more attention to our user stories.

These success stories are a major component for the Jenkins community and should be placed in a more prominent location.
Currently, they aren't displayed in any prominent location.