### PR TITLE
feat: Replace CC by-sa banner with SVG

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -18,7 +18,10 @@ const licenseHtmls = {
      <div id="creativecommons">
         <a href="https://creativecommons.org/licenses/by-sa/4.0/">
            <p>
-              <img alt=${msg('Creative Commons Attribution-ShareAlike license')} src="https://licensebuttons.net/l/by-sa/4.0/88x31.png">
+              <img alt=${msg('Creative Commons Attribution-ShareAlike license')}
+                   src="https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg"
+                   width="88" height="31"
+              >
            </p>
         </a>
         <p>


### PR DESCRIPTION
A minor change replacing the banner with the SVG one, to ensure the image is reactive on different devices, instead of being blurry.

Before:
![Screenshot 2023-05-13 at 13 54 22](https://github.com/jenkins-infra/jenkins-io-components/assets/13383509/ce350c6d-63f1-4cd7-ad85-db45d4f531b7)

After:
![Screenshot 2023-05-13 at 13 54 13](https://github.com/jenkins-infra/jenkins-io-components/assets/13383509/b6c835c3-8059-45bf-a4c9-7c7dd438777c)