### PR TITLE
refactor: Add links to advisories, remove links to less relevant pages

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -156,10 +156,10 @@ export class Navbar extends LitElement {
           {
             label: msg("Overview"), link: "/security/"
           },
+          {label: msg("Security Advisories"), link: "/security/advisories/"},
           {label: msg("For Administrators"), link: "/security/for-administrators/"},
           {label: msg("For Reporters"), link: "/security/reporting/"},
           {label: msg("For Maintainers"), link: "/security/for-maintainers/"},
-          {label: msg("Jenkins Security Team"), link: "/security/team/"},
         ]
       },
       {

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -157,9 +157,7 @@ export class Navbar extends LitElement {
             label: msg("Overview"), link: "/security/"
           },
           {label: msg("Security Advisories"), link: "/security/advisories/"},
-          {label: msg("For Administrators"), link: "/security/for-administrators/"},
-          {label: msg("For Reporters"), link: "/security/reporting/"},
-          {label: msg("For Maintainers"), link: "/security/for-maintainers/"},
+          {label: msg("Reporting Vulnerabilities"), link: "/security/reporting/"},
         ]
       },
       {


### PR DESCRIPTION
The sidepanel sections of https://www.jenkins.io/security/ and related pages do not make a great selection of menu entries.

This essentially replaces those with the main content areas of https://www.jenkins.io/security/ (security advisories and vulnerability reporting), which we expect are far more relevant for most visitors.

Untested.

CC @Wadeck 