### PR TITLE
chore: Lower log level of "locale not found" message

### DIFF
--- a/src/jio-locale.ts
+++ b/src/jio-locale.ts
@@ -21,7 +21,7 @@ export const setLocaleFromUrl = async () => {
   const locale = url.searchParams.get('locale') || (new Intl.NumberFormat()).resolvedOptions().locale || sourceLocale;
   await setLocale(locale);
 };
-setLocaleFromUrl().catch(e => console.error(`Error loading locale: ${(e as Error).message}`));
+setLocaleFromUrl().catch(e => console.log(`Error loading locale: ${(e as Error).message}`));
 
 
 window.addEventListener('jio-locale-changed', (e) => {


### PR DESCRIPTION
This is not an error and should not be logged as such.