### PR TITLE
feat: reduce font-size of navbar and download button

### DIFF
--- a/src/jio-navbar.css
+++ b/src/jio-navbar.css
@@ -30,7 +30,7 @@ button:not(:disabled) {
   background: #212529;
   display: flex;
   flex-wrap: wrap;
-  font-size: 0.875rem;
+  font-size: 0.825rem;
   justify-content: space-between;
   padding: 0.5rem 0;
   padding: 0.5rem 1rem;
@@ -155,7 +155,7 @@ button.nav-link {
 }
 
 .download-btn {
-  font-size: 0.875rem;
+  font-size: 0.825rem;
   margin-left: 8px;
 }
 

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -199,7 +199,7 @@ export class Navbar extends LitElement {
       <nav class="navbar" data-theme=${this.theme}>
         <span class="navbar-brand">
           <slot name="brand">
-            <a href="/">Jenkins</a>
+            <a href="https://www.jenkins.io/">Jenkins</a>
           </slot>
         </span>
         <button

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -199,7 +199,7 @@ export class Navbar extends LitElement {
       <nav class="navbar" data-theme=${this.theme}>
         <span class="navbar-brand">
           <slot name="brand">
-            <a href="https://www.jenkins.io/">Jenkins</a>
+            <a href="/">Jenkins</a>
           </slot>
         </span>
         <button

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -93,8 +93,8 @@ export class Navbar extends LitElement {
     ];
     const menuItems = [
       {label: msg("Blog"), link: "/node"},
-      {label: msg("Success Stories"), link: "https://stories.jenkins.io/"},
-      {label: msg("Contributor Spotlight"), link: "https://contributors.jenkins.io/"},
+      {label: msg("Stories"), link: "https://stories.jenkins.io/"},
+      {label: msg("Contributors"), link: "https://contributors.jenkins.io/"},
       {
         label: msg("Documentation"), link: [
           {


### PR DESCRIPTION
1. Decreased the font-size of navbar and download button from 0.875rem to 0.8rem so it would not collapse to two rows when small laptop screen size is slightly reduced. 
2. ~~Set "Jenkins" <a> tag to redirect to "https://www.jenkins.io/".~~
3. Update wording of buttons from "Success Stories" to "Stories" and "Contributor Spotlight" to "Contributors". 

c.c. @lemeurherve @alyssat @jmMeessen @gounthar @MarkEWaite 