### PR TITLE
feat: make Jenkins logo text redirects to jenkins.io on click

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -199,7 +199,7 @@ export class Navbar extends LitElement {
       <nav class="navbar" data-theme=${this.theme}>
         <span class="navbar-brand">
           <slot name="brand">
-            <a href="/">Jenkins</a>
+            <a href="https://www.jenkins.io/">Jenkins</a>
           </slot>
         </span>
         <button


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/contributor-spotlight/issues/42

Redirects users to https://www.jenkins.io/ instead of root `/` upon their clicking of the Jenkins logo text. 

c.c. @kmartens27 @MarkEWaite @alyssat @jmMeessen @gounthar