### PR TITLE
feat: updating twitter to x (formerly twitter)

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -151,7 +151,7 @@ export class Footer extends LitElement {
                               <a href=${relOrAbsoluteLink('/sigs/', this.property).href}>${msg('Special Interest Groups')}</a>
                            </li>
                            <li>
-                              <a href=${relOrAbsoluteLink('https://twitter.com/jenkinsci', this.property).href}>${msg('Twitter')}</a>
+                              <a href=${relOrAbsoluteLink('https://twitter.com/jenkinsci', this.property).href}>${msg('X (formerly Twitter)')}</a>
                            </li>
                            <li>
                               <a href=${relOrAbsoluteLink('https://reddit.com/r/jenkinsci', this.property).href}>${msg('Reddit')}</a>

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -151,7 +151,7 @@ export class Footer extends LitElement {
                               <a href=${relOrAbsoluteLink('/sigs/', this.property).href}>${msg('Special Interest Groups')}</a>
                            </li>
                            <li>
-                              <a href=${relOrAbsoluteLink('https://twitter.com/jenkinsci', this.property).href}>${msg('X (formerly Twitter)')}</a>
+                              <a href=${relOrAbsoluteLink('https://twitter.com/jenkinsci', this.property).href}>${msg('𝕏 (formerly Twitter)')}</a>
                            </li>
                            <li>
                               <a href=${relOrAbsoluteLink('https://reddit.com/r/jenkinsci', this.property).href}>${msg('Reddit')}</a>


### PR DESCRIPTION
This PR is to suggest changing the Twitter text at in the footer to be "X (formerly Twitter)" so that we stay current with naming/branding.

This is in response to discussion being had during the [January 11 Advocacy & Outreach meeting](https://community.jenkins.io/t/advocacy-outreach-sig-meeting-2024-01-11/11739)

Several other projects are still using _just_ Twitter, but the CD Foundation is using the X logo, so we want to try and align with them as best we can.

If there are any thoughts or feelings against this idea, it would be great to see other examples of how this is being addressed. 