### PR TITLE
fix: Correct link direction in footer - code of conduct

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -164,7 +164,7 @@ export class Footer extends LitElement {
                         <h5>Other</h5>
                         <ul class="other">
                            <li>
-                              <a href=${relOrAbsoluteLink('/conduct/', this.property).href}>${msg('Code of Conduct')}</a>
+                              <a href=${relOrAbsoluteLink('/project/conduct/', this.property).href}>${msg('Code of Conduct')}</a>
                            </li>
                            <li>
                               <a href=${relOrAbsoluteLink('/press/', this.property).href}>${msg('Press information')}</a>


### PR DESCRIPTION
this **PR** contains correcting the direction of footer element which is 'Code of Conduct' to direct to the right page
a workaround was created in jenkins.io repository which is redirecting from `'/conduct'` to `'/project/conduct' `
but this **PR** solves the problem 


issue related: #132 