### PR TITLE
feat: add link to infra stats page in footer

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -128,6 +128,9 @@ export class Footer extends LitElement {
                            <li>
                               <a href=${relOrAbsoluteLink('https://ci.jenkins.io', this.property).href}>${msg('Jenkins on Jenkins')}</a>
                            </li>
+                           <li>
+                              <a href=${relOrAbsoluteLink('https://stats.jenkins.io', this.property).href}>${msg('Jenkins Infra Statistics')}</a>
+                           </li>
                         </ul>
                      </div>
                   </div>

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -129,7 +129,7 @@ export class Footer extends LitElement {
                               <a href=${relOrAbsoluteLink('https://ci.jenkins.io', this.property).href}>${msg('Jenkins on Jenkins')}</a>
                            </li>
                            <li>
-                              <a href=${relOrAbsoluteLink('https://stats.jenkins.io', this.property).href}>${msg('Jenkins Infra Statistics')}</a>
+                              <a href=${relOrAbsoluteLink('https://stats.jenkins.io', this.property).href}>${msg('Statistics')}</a>
                            </li>
                         </ul>
                      </div>


### PR DESCRIPTION
This PR adds a link to the Jenkins Infra Stats website that is being revamped as part of GSoC 2024.

![Screenshot 2024-07-25 at 11 43 55 AM](https://github.com/user-attachments/assets/2e56ec1b-182f-424c-bb5e-c00f8986fdc2)

closes #147 

ref:
- https://github.com/jenkins-infra/stats.jenkins.io/issues/88

@krisstern @gounthar 

