### PR TITLE
fix: correct tooltip position for dropdown menu of smaller screens

### DIFF
--- a/src/jio-navbar.css
+++ b/src/jio-navbar.css
@@ -140,6 +140,9 @@ button.nav-link {
   min-width: 10rem;
   padding: 0.5em 0;
   position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
   text-align: left;
   z-index: 1000;
 }


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/contributor-spotlight/issues/208

1. Addressed issue created in https://github.com/jenkins-infra/contributor-spotlight/issues/208
2. Previously the dropdown menu was on left side in smaller screen across all Jenkins website
3. Fixed issue and made the tooltip positioning responsive for every size of the screen
4. Attachment:

https://github.com/user-attachments/assets/2628a9af-7167-4d3c-b31f-081caec4b082

