### PR TITLE
fix: move function definition outside of scope of render

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -69,16 +69,13 @@ export class Footer extends LitElement {
    reportAProblemTemplate = "";
 
    override render() {
-      // Check if the current page is /download or /download/mirrors
-      const isADownloadsPage = this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
-
       return html`
 <footer>
    <div class="container">
       <div class="row">
          <div class="col-md-4 col1">
             <p class="box">
-               ${isADownloadsPage
+               ${this.isADownloadsPage()
                   ? html`<jio-report-infra-issue sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)}></jio-report-infra-issue>`
                   : nothing
                }
@@ -199,6 +196,11 @@ export class Footer extends LitElement {
    </div>
 </footer>
     `;
+   }
+
+   private isADownloadsPage() {
+      // Check if the current page is /download or /download/mirrors
+      return this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
    }
 }
 

--- a/src/jio-navbar.css
+++ b/src/jio-navbar.css
@@ -4,8 +4,7 @@ a:focus-visible {
 
 .navbar-toggler {
   background-color: transparent;
-  border: 1px solid transparent;
-  border-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.25rem;
   color: rgba(255, 255, 255, 0.5);
   display: none;
@@ -54,14 +53,11 @@ button:not(:disabled) {
 
   /* FIXME - should this stay generic fonts? */
   font-family: Georgia, Times, "Times New Roman", serif;
-  font-size: 1.25rem;
   font-size: 20px;
   font-weight: 600;
   line-height: inherit;
   margin-right: 1rem;
-  padding: 2px 0;
-  padding-bottom: 0.3125rem;
-  padding-top: 0.3125rem;
+  padding: 0.3125rem 0;
   text-decoration: none;
   white-space: nowrap;
 }
@@ -122,8 +118,6 @@ button.nav-link {
   color: rgba(255, 255, 255, 0.55);
   display: block;
   padding: 0.5em 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   text-decoration: none;
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
     border-color 0.15s ease-in-out;


### PR DESCRIPTION
1. Moved function to check whether page has path `/download/` or `/download/mirrors/` to outside of render() to make sure it is re-rendered after the first time. 
2. Fixed some src/jio-navbar.css CSS styling issues. 