### PR TITLE
fix: correct `report-infra-issue` to show only on download and download/mirror pages

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -69,10 +69,10 @@ export class Footer extends LitElement {
    reportAProblemTemplate = "";
 
    @property({ type: Boolean })
-   skipReportIssue = false;
+   skipReportIssue = true;
 
-   private get isADownloadsPage() {
-     return this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
+   private isADownloadsPage() {
+     this.skipReportIssue = !(this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/'));
    }
 
    override render() {
@@ -81,7 +81,7 @@ export class Footer extends LitElement {
    <div class="container">
       <div class="row">
          <div class="col-md-4 col1">
-            ${this.isADownloadsPage && !this.skipReportIssue
+            ${!this.skipReportIssue
                ? html`<p class="box"><jio-report-infra-issue sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)}></jio-report-infra-issue></p>`
                : nothing
             }

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -71,6 +71,7 @@ export class Footer extends LitElement {
    @property({ type: Boolean })
    skipReportIssue = false;
 
+   /** Change to include the report infra issue link */
    private get isADownloadsPage() {
      return this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
    }

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -71,7 +71,6 @@ export class Footer extends LitElement {
    @property({ type: Boolean })
    skipReportIssue = false;
 
-   /** Change to include the report infra issue link */
    private get isADownloadsPage() {
      return this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
    }

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -71,13 +71,17 @@ export class Footer extends LitElement {
    @property({ type: Boolean })
    skipReportIssue = false;
 
+   private get isADownloadsPage() {
+     return this.sourcePath.includes('/download/') || this.sourcePath.includes('/download/mirrors/');
+   }
+
    override render() {
       return html`
 <footer>
    <div class="container">
       <div class="row">
          <div class="col-md-4 col1">
-            ${!this.skipReportIssue
+            ${this.isADownloadsPage && !this.skipReportIssue
                ? html`<p class="box"><jio-report-infra-issue sourcePath=${this.sourcePath} githubRepo=${this.githubRepo} .githubBranch=${ifDefined(this.githubBranch)}></jio-report-infra-issue></p>`
                : nothing
             }


### PR DESCRIPTION
### Description

we were having the "Report infra issue" in all pages of jenkins.io which wasnt the intended changes..We should have it only in the download and download/mirror pages..
This PR tries to resolve that.