### PR TITLE
fix: report-infra-issue to load in download and download/mirrors/ pages

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -76,6 +76,7 @@ export class Footer extends LitElement {
    }
 
    override render() {
+      this.isADownloadsPage();
       return html`
 <footer>
    <div class="container">


### PR DESCRIPTION
Follow up of #161 to show the `report-infra-issue` in the download and download/mirror page