### PR TITLE
feat: Add CDF copyright text and links

### DIFF
--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -200,6 +200,18 @@ export class Footer extends LitElement {
          </div>
       </div>
    </div>
+   <div class="container">
+          <div class="footer-content">
+            <p>
+              Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
+              The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 
+              <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage</a> page.
+              Linux is a registered trademark of Linus Torvalds. 
+              <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank">Privacy Policy</a> and 
+              <a href="https://www.linuxfoundation.org/legal/terms" target="_blank">Terms of Use</a>.
+            </p>
+          </div>
+        </div>
 </footer>
     `;
    }

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -201,17 +201,17 @@ export class Footer extends LitElement {
       </div>
    </div>
    <div class="container">
-          <div class="footer-content">
-            <p>
-              Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
-              The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 
-              <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage</a> page.
-              Linux is a registered trademark of Linus Torvalds. 
-              <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank">Privacy Policy</a> and 
-              <a href="https://www.linuxfoundation.org/legal/terms" target="_blank">Terms of Use</a>.
-            </p>
-          </div>
-        </div>
+    <div class="footer-content">
+      <p>
+        Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
+        The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 
+        <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage</a> page.
+        Linux is a registered trademark of Linus Torvalds. 
+        <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank">Privacy Policy</a> and 
+        <a href="https://www.linuxfoundation.org/legal/terms" target="_blank">Terms of Use</a>.
+      </p>
+    </div>
+  </div>
 </footer>
     `;
    }

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -201,7 +201,7 @@ export class Footer extends LitElement {
       </div>
    </div>
    <div class="container">
-     <div class="footer-content">
+     <div class="row">
         <p>
            Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
            The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 

--- a/src/jio-footer.ts
+++ b/src/jio-footer.ts
@@ -201,17 +201,17 @@ export class Footer extends LitElement {
       </div>
    </div>
    <div class="container">
-    <div class="footer-content">
-      <p>
-        Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
-        The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 
-        <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage</a> page.
-        Linux is a registered trademark of Linus Torvalds. 
-        <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank">Privacy Policy</a> and 
-        <a href="https://www.linuxfoundation.org/legal/terms" target="_blank">Terms of Use</a>.
-      </p>
-    </div>
-  </div>
+     <div class="footer-content">
+        <p>
+           Copyright © 2025 CD Foundation The Linux Foundation®. All rights reserved.
+           The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our 
+            <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage</a> page.
+           Linux is a registered trademark of Linus Torvalds. 
+            <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank">Privacy Policy</a> and 
+            <a href="https://www.linuxfoundation.org/legal/terms" target="_blank">Terms of Use</a>.
+         </p>
+      </div>
+   </div>
 </footer>
     `;
    }


### PR DESCRIPTION
From the [Advocacy & Outreach SIG meeting on May 15](https://community.jenkins.io/t/2025-may-15-advocacy-outreach-sig-meeting/31270/2), CD Foundation has asked that we include their copyright/terms of use information on the jenkins.io site. I have added the requested text and links to the footer of the page so that it is present in all areas.

Storybook preview:
<img width="1723" alt="Screenshot 2025-05-16 at 9 51 44 AM" src="https://github.com/user-attachments/assets/fa8b0129-564b-4920-a2b6-89910c1e1bcc" />
