### PR TITLE
fix: use absolute URLs for navbar links to resolve 404s(#227)

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -98,7 +98,7 @@ export class Navbar extends LitElement {
       {
         label: msg("Documentation"), link: [
           {
-            label: msg("User Guide"), link: "/doc/book", header: true
+            label: msg("User Guide"), link: "https://www.jenkins.io/doc/book/", header: true
           },
           {label: "- " + msg("Installing Jenkins"), link: "/doc/book/installing/"},
           {label: "- " + msg("Jenkins Pipeline"), link: "/doc/book/pipeline/"},
@@ -109,10 +109,10 @@ export class Navbar extends LitElement {
           {label: "- " + msg("Terms and Definitions"), link: "/doc/book/glossary/"},
           {label: msg("Solution Pages"), link: "/solutions", header: true},
           {
-            label: msg("Tutorials"), link: "/doc/tutorials", header: true
+            label: msg("Tutorials"), link: "https://www.jenkins.io/doc/tutorials/", header: true
           },
           {
-            label: msg("Developer Guide"), link: "/doc/developer", header: true
+            label: msg("Developer Guide"), link: "https://www.jenkins.io/doc/developer/", header: true
           },
           {label: msg("Contributor Guide"), link: "/participate", header: true},
           {label: msg("Books"), link: "/books", header: true},


### PR DESCRIPTION
# Problem
Currently, the jio-navbar component uses relative paths (e.g., /doc/book) for the User Guide and Tutorials links. While these work on the primary www.jenkins.io domain, they result in 404 Not Found errors when the navbar is rendered on subdomains like docs.jenkins.io or plugins.jenkins.io, as those sites do not host the same content structure.

# Solution
I have updated the navigation configuration in src/jio-navbar.ts to use absolute URLs. This ensures that the links always point back to the authoritative source of documentation on the main Jenkins website, regardless of which subdomain the component is being served from.

# Changes
- src/jio-navbar.ts: Updated User Guide link from /doc/book to https://www.jenkins.io/doc/book/.
- src/jio-navbar.ts: Updated Tutorials link from /doc/tutorials to https://www.jenkins.io/doc/tutorials/.

# Result
[screen-capture (2).webm](https://github.com/user-attachments/assets/efe82aa4-21c3-4d80-82f3-ec2623e42e30)


# Related Issue
Fixes #227 (or Closes #227)