### PR TITLE
fix: Change Jenkins X to JayeX in `jio-navbar`

### DIFF
--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -87,7 +87,7 @@ export class Navbar extends LitElement {
   override render() {
     const cdfMenuItems = [
       {label: msg("What is CDF?"), link: "https://cd.foundation/"},
-      {label: msg("Jenkins X"), link: "https://jenkins-x.io/"},
+      {label: msg("JayeX"), link: "https://jenkins-x.io/"},
       {label: msg("Tekton"), link: "https://tekton.dev/"},
       {label: msg("Spinnaker"), link: "https://www.spinnaker.io/"},
     ];

--- a/src/jio-navbar.ts
+++ b/src/jio-navbar.ts
@@ -87,7 +87,7 @@ export class Navbar extends LitElement {
   override render() {
     const cdfMenuItems = [
       {label: msg("What is CDF?"), link: "https://cd.foundation/"},
-      {label: msg("JayeX"), link: "https://jenkins-x.io/"},
+      {label: msg("JayeX"), link: "https://jayex.io/"},
       {label: msg("Tekton"), link: "https://tekton.dev/"},
       {label: msg("Spinnaker"), link: "https://www.spinnaker.io/"},
     ];


### PR DESCRIPTION
Name of Jenkins X has been changed to JayeX two weeks ago which was officially announced by CDF foundation. 
reference: 
https://cd.foundation/blog/2026/04/16/announcing-jayex/?utm_content=375726637&utm_medium=social&utm_source=linkedin&hss_channel=lcp-19100461

### Screenshot
<img width="932" height="476" alt="image" src="https://github.com/user-attachments/assets/2e83e1b9-fe2a-405c-8834-56af4fba961d" />

closes #193 