### PR TITLE
chore(Jenkinsfile): remove asdf, rely on packer-images node.js

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,12 +29,18 @@ pipeline {
       }
     }
 
+    stage('Check Tooling') {
+      steps {
+        sh 'node --version'
+        sh 'npm --version'
+      }
+    }
+
     stage('Install Dependencies') {
       environment {
         NODE_ENV = 'development'
       }
       steps {
-        sh 'asdf install'
         sh 'npm ci'
         sh 'npx playwright install'
       }


### PR DESCRIPTION
Ref:
- jenkins-infra/helpdesk#5093

Remove ASDF from the plugin-site build and rely on the Node.js version installed on packer-images agents (tracked by updatecli).
