### PR TITLE
chore(Jenkinsfile) add build report publishing for main branch monitoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,5 +184,11 @@ pipeline {
         }
       }
     }
+
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5159

This PR adds a publishBuildStatusReport() stage for main branch builds