### PR TITLE
chore(Jenkinsfile): trigger daily build on principal branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,10 @@
+// Do not trigger daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
+String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+
 pipeline {
+  triggers {
+    cron(cronPattern)
+  }
   options {
     timeout(time: 60, unit: 'MINUTES')
     ansiColor('xterm')


### PR DESCRIPTION
Ref:
-  https://github.com/jenkins-infra/helpdesk/issues/5159

Add a daily cron trigger on the principal branch so the build report is refreshed at least once every 24h.