### PR TITLE
docs: document ionicons cdn for both legacy and modern browsers

### DIFF
--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -34,6 +34,7 @@ For this element to work from unpkg.com specifically, you need to include the `?
 
 ```html
 <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
 ```
 
 #### Mix of modern and legacy
@@ -46,6 +47,8 @@ For this element to work from unpkg.com specifically, you need to include the `?
 <!-- load the components (module for modern, cjs for legacy) -->
 <script data="jio" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module" type="module"></script>
 <script data="jio" nomodule="" src="https://unpkg.com/@jenkinsci/jenkins-io-components"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.js"></script>
 ````
 
 ## Usage

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -34,7 +34,7 @@ For this element to work from unpkg.com specifically, you need to include the `?
 
 ```html
 <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
-<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
 ```
 
 #### Mix of modern and legacy
@@ -47,8 +47,8 @@ For this element to work from unpkg.com specifically, you need to include the `?
 <!-- load the components (module for modern, cjs for legacy) -->
 <script data="jio" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module" type="module"></script>
 <script data="jio" nomodule="" src="https://unpkg.com/@jenkinsci/jenkins-io-components"></script>
-<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js"></script>
-<script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.js"></script>
 ````
 
 ## Usage

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -47,8 +47,8 @@ For this element to work from unpkg.com specifically, you need to include the `?
 <!-- load the components (module for modern, cjs for legacy) -->
 <script data="jio" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module" type="module"></script>
 <script data="jio" nomodule="" src="https://unpkg.com/@jenkinsci/jenkins-io-components"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
-<script nomodule src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.js"></script>
+<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js"></script>
+<script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.js"></script>
 ````
 
 ## Usage

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -34,7 +34,7 @@ For this element to work from unpkg.com specifically, you need to include the `?
 
 ```html
 <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
+<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.5.2/ionicons/ionicons.esm.js"></script>
 ```
 
 #### Mix of modern and legacy


### PR DESCRIPTION
This Pr adds important cdn scripts in introduction page of story book about ionicons
fixes: #213 